### PR TITLE
Add experimental remoteBindings as cloudflareDev-option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can configure additional options using `cloudflareDev: { }` in `nitro.config
 - `configPath`: Sets a custom path for `wrangler.toml` file.
 - `silent`: Hide initial banner.
 - `environment`: Sets specific environment (useful for multi-environment configurations)
+- `remoteBindings`: Enable Wrangler's experimental remoteBindings.
 
 ## Development
 

--- a/examples/nitro/nitro.config.ts
+++ b/examples/nitro/nitro.config.ts
@@ -2,5 +2,8 @@ import nitroCloudflareBindings from "nitro-cloudflare-dev";
 
 // https://nitro.unjs.io/config
 export default defineNitroConfig({
-  modules: [nitroCloudflareBindings]
+  modules: [nitroCloudflareBindings],
+  // cloudflareDev: {
+  //   remoteBindings: true
+  // }
 });

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -2,4 +2,9 @@
 export default defineNuxtConfig({
   modules: ["nitro-cloudflare-dev"],
   compatibilityDate: "2024-10-10",
+  // nitro: {
+  //   cloudflareDev: {
+  //     remoteBindings: true,
+  //   },
+  // }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ declare module "nitropack" {
       environment?: string;
       persistDir?: string;
       silent?: boolean;
+      remoteBindings?: boolean;
     };
   }
 }
@@ -65,7 +66,12 @@ async function nitroModule(nitro: Nitro) {
         "",
         `Config path: \`${configPath ? relative(".", configPath) : colorize("yellow", "cannot find `wrangler.json`, `wrangler.jsonc`, or `wrangler.toml`")}\``,
         `Persist dir: \`${relative(".", persistDir)}\` ${addedToGitIgnore ? colorize("green", "(added to `.gitignore`)") : ""}`,
-      ].join("\n"),
+        nitro.options.cloudflareDev?.remoteBindings
+          ? `Remote bindings: ${colorize("green", "enabled")} (🧪 experimental)`
+          : undefined,
+      ]
+        .filter((row) => row !== undefined)
+        .join("\n"),
     );
   }
 
@@ -75,6 +81,7 @@ async function nitroModule(nitro: Nitro) {
     configPath,
     persistDir,
     environment: nitro.options.cloudflareDev?.environment,
+    remoteBindings: nitro.options.cloudflareDev?.remoteBindings,
   };
 
   // Make sure runtime is transpiled

--- a/src/runtime/plugin.dev.ts
+++ b/src/runtime/plugin.dev.ts
@@ -68,12 +68,16 @@ async function _getPlatformProxy() {
       configPath: string;
       persistDir: string;
       environment?: string;
+      remoteBindings?: boolean;
     };
   } = useRuntimeConfig();
 
   const proxyOptions: GetPlatformProxyOptions = {
     configPath: runtimeConfig.wrangler.configPath,
     persist: { path: runtimeConfig.wrangler.persistDir },
+    ...(runtimeConfig.wrangler.remoteBindings && {
+      experimental: { remoteBindings: true },
+    }),
   };
   // TODO: investigate why
   // https://github.com/pi0/nitro-cloudflare-dev/issues/51


### PR DESCRIPTION
This adds the possibility to activate remote bindings. (`wrangler dev --x-remote-bindings`).

I know this package is soon to be deprecated, with Nitro 2.12.
However I haven't found a way to activate `--x-remote-bindings` with nuxt.

This makes it easy,
just add 

```ts
nitro: {
  cloudflareDev: {
    remoteBindings: true,
  }
}
```

to `nuxt.config.ts`.